### PR TITLE
AK-326 [Feat] OpenFeign 예외 핸들링 보완

### DIFF
--- a/src/main/java/com/alphaka/authservice/exception/ErrorCode.java
+++ b/src/main/java/com/alphaka/authservice/exception/ErrorCode.java
@@ -9,9 +9,12 @@ public record ErrorCode(int status, String code, String message) {
     public static final ErrorCode SMS_VERIFICATION_FAILURE =
             new ErrorCode(HttpStatus.BAD_REQUEST.value(), "USR004", "인증번호가 일치하지 않습니다.");
 
-    public static final ErrorCode AUTHENTICATION_FAILURE =
+    public static final ErrorCode INVALID_EMAIL_OR_PASSWORD =
             new ErrorCode(HttpStatus.UNAUTHORIZED.value(), "USR013", "이메일 혹은 비밀번호가 일치하지 않습니다.");
 
     public static final ErrorCode DESERIALIZATION_FAILURE =
             new ErrorCode(HttpStatus.BAD_REQUEST.value(), "USR009", "읽을 수 없는 요청입니다.");
+
+    public static final ErrorCode AUTHENTICATION_SERVICE_FAILURE =
+            new ErrorCode(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SYS001", "서버에서 문제가 발생했습니다.");
 }

--- a/src/main/java/com/alphaka/authservice/exception/custom/AuthenticationFailureException.java
+++ b/src/main/java/com/alphaka/authservice/exception/custom/AuthenticationFailureException.java
@@ -5,6 +5,6 @@ import com.alphaka.authservice.exception.ErrorCode;
 public class AuthenticationFailureException extends CustomException {
 
     public AuthenticationFailureException() {
-        super(ErrorCode.AUTHENTICATION_FAILURE);
+        super(ErrorCode.INVALID_EMAIL_OR_PASSWORD);
     }
 }

--- a/src/main/java/com/alphaka/authservice/openfeign/decoder/CustomErrorDecoder.java
+++ b/src/main/java/com/alphaka/authservice/openfeign/decoder/CustomErrorDecoder.java
@@ -1,34 +1,29 @@
 package com.alphaka.authservice.openfeign.decoder;
 
-import com.alphaka.authservice.dto.response.ErrorResponse;
 import com.alphaka.authservice.exception.ErrorCode;
 import com.alphaka.authservice.exception.custom.CustomException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Response;
 import feign.codec.ErrorDecoder;
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 @Slf4j
 public class CustomErrorDecoder implements ErrorDecoder {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
+    // 오픈페인 요청 응답이 왔을 때 상태코드가 4XX, 5XX일 때 동작
     @Override
     public Exception decode(String methodKey, Response response) {
 
-        try {
-            log.error("오픈페인 요청 중 오류가 발생했습니다.");
-            ErrorResponse errorResponse = objectMapper.readValue(response.body().asInputStream(), ErrorResponse.class);
+        int status = response.status();
+        log.error("오픈페인 요청 중 오류가 발생했습니다.");
+        log.error("오류 response.stataus: {}", status);
 
-            return new CustomException(new ErrorCode(errorResponse.getStatus(), errorResponse.getCode(),
-                    errorResponse.getMessage()));
-        } catch (IOException e) {
-            //역직렬화 실패
-            throw new CustomException(new ErrorCode(HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                    "", "오류가 발생했습니다."));
+        // 존재하지 않는 사용자
+        if (status == 404) {
+            return new UsernameNotFoundException("존재하지 않는 사용자입니다.");
         }
 
+        return new CustomException(ErrorCode.AUTHENTICATION_SERVICE_FAILURE);
     }
+
 }

--- a/src/main/java/com/alphaka/authservice/security/config/SecurityConfig.java
+++ b/src/main/java/com/alphaka/authservice/security/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager() {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(customUserService);
+        // UserNotFoundException을 BadCredentialException으로 변환하지 않게 한다.
+        provider.setHideUserNotFoundExceptions(false);
         return new ProviderManager(provider);
     }
 

--- a/src/main/java/com/alphaka/authservice/security/login/handler/CustomLoginFailureHandler.java
+++ b/src/main/java/com/alphaka/authservice/security/login/handler/CustomLoginFailureHandler.java
@@ -1,15 +1,21 @@
 package com.alphaka.authservice.security.login.handler;
 
-import com.alphaka.authservice.exception.custom.AuthenticationFailureException;
+import com.alphaka.authservice.dto.response.ErrorResponse;
+import com.alphaka.authservice.exception.ErrorCode;
 import com.alphaka.authservice.redis.service.LoginAttemptService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
@@ -19,19 +25,59 @@ import org.springframework.stereotype.Component;
 public class CustomLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     private final LoginAttemptService loginAttemptService;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException, ServletException {
         log.info("자체 로그인 실패: {}", exception.getMessage());
 
-        // 비밀번호 틀린 경우
-        if (exception instanceof BadCredentialsException) {
-            String email = (String) request.getAttribute("X-Login-Attempt-Email");
-            log.info("틀린 비밀번호 입니다.");
-            loginAttemptService.loginFail(email);
+        ErrorCode errorCode;
+        ErrorResponse errorResponse;
+
+        // 인증 시도 중 문제 발생, 스프링 시큐리티가 오픈페인 시큐리티 예외로 래핑하여 던짐
+        if (exception instanceof InternalAuthenticationServiceException) {
+            log.error("인증 시도 중 문제가 발생했습니다.");
+            log.error("다른 서비스의 상태를 확인해주세요.");
+
+            errorCode = ErrorCode.AUTHENTICATION_SERVICE_FAILURE;
+            errorResponse = new ErrorResponse(
+                    errorCode.status(),
+                    errorCode.code(),
+                    errorCode.message()
+            );
+
+            setHttpResponse(response, errorResponse);
+            return;
         }
 
-        throw new AuthenticationFailureException();
+        if (exception instanceof UsernameNotFoundException) {
+            log.error("존재하지 않는 사용자입니다.");
+
+        } else if (exception instanceof BadCredentialsException) {
+            log.info("틀린 비밀번호입니다.");
+            String email = (String) request.getAttribute("X-Login-Attempt-Email");
+            loginAttemptService.loginFail(email);
+
+        }
+
+        // 보안 문제로 이메일과 비밀번호 중 무엇이 틀렸는지는 외부에 노출하지 않는다.
+        errorCode = ErrorCode.INVALID_EMAIL_OR_PASSWORD;
+        errorResponse = new ErrorResponse(
+                errorCode.status(),
+                errorCode.code(),
+                errorCode.message()
+        );
+
+        setHttpResponse(response, errorResponse);
+
+    }
+
+    private void setHttpResponse(HttpServletResponse response, ErrorResponse errorResponse) throws IOException {
+        response.setStatus(errorResponse.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/alphaka/authservice/security/login/service/CustomUserService.java
+++ b/src/main/java/com/alphaka/authservice/security/login/service/CustomUserService.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -24,16 +23,22 @@ public class CustomUserService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        log.info("유저 서비스에 이메일({})로 사용자 조회", email);
-        UserSignInResponse response = userServiceClient.signIn(
-                new UserSignInRequest(email, null)).getData();
+
+        try {
+            log.info("유저 서비스에 이메일({})로 사용자 조회", email);
+            UserSignInResponse response = userServiceClient.signIn(
+                    new UserSignInRequest(email, null)).getData();
 
 
-        return new CustomUser(String.valueOf(response.getId()), response.getPassword(),
-                Collections.singleton(new SimpleGrantedAuthority(response.getRole().getValue())),
-                response.getNickname(),
-                response.getProfileImage(),
-                response.getRole()
-                );
+            return new CustomUser(String.valueOf(response.getId()), response.getPassword(),
+                    Collections.singleton(new SimpleGrantedAuthority(response.getRole().getValue())),
+                    response.getNickname(),
+                    response.getProfileImage(),
+                    response.getRole()
+            );
+        } catch (Exception ex) {
+            log.error("사용자 조회 실패");
+            throw ex;
+        }
     }
 }


### PR DESCRIPTION
## 📌 Summary
해당 PR에서 구현하거나 수정한 내용의 요약을 작성해주세요.

- 자체 로그인 인증 시, 오픈페인을 사용하면서 발생할 수 있는 예외들에 대한 핸들링 보완

## 📝 Changes
변경된 주요 사항을 항목별로 정리해주세요.

- 자체 로그인 인증 과정 중에 예외가 발생하는 경우에 응답 바디에 ErrorResponse가 담기게 수정
- 존재하지 않는 사용자 계정에 대해서도 로그인 시도 횟수를 관리하던 로직 수정

## ✅ Checklist
PR을 제출하기 전에 확인해야 할 사항들을 체크하세요. (✓)

- [x] 코드가 정상적으로 컴파일되고 작동하는지 확인했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 문서 업데이트가 필요한 경우 업데이트했습니다.

## 🔗 Related Issue
연관된 이슈 번호를 기재해주세요. (e.g., AK-201)

- AK-326

## 📸 Screenshots (Optional)
필요에 따라 스크린샷을 첨부하여 설명해주세요.

- 